### PR TITLE
Replaced jquery "attr" with "prop"

### DIFF
--- a/src/rating.js
+++ b/src/rating.js
@@ -119,8 +119,8 @@
             });
             
             matchInput
-                .attr('checked', true)
-				.siblings('input').attr('checked', false);
+                .prop('checked', true)
+				.siblings('input').prop('checked', false);
             
             container
                 .trigger('set.rating', matchInput.val())


### PR DESCRIPTION
jQuery's ':checked' selector doesn't work properly when the input's checked attribute is set through "attr". It works fine when using "prop".
